### PR TITLE
[Chore]: HTTPS 적용 및 도메인 기반 프론트 쿠키 수정 및 엔드포인트 통일

### DIFF
--- a/glym_spring/src/main/java/glym/glym_spring/auth/docs/AuthDocs.java
+++ b/glym_spring/src/main/java/glym/glym_spring/auth/docs/AuthDocs.java
@@ -199,7 +199,7 @@ public interface AuthDocs {
                 - JSON Body:
                 ```json
                 {
-                  "email": "example@example.com",
+                  "to": "example@example.com",
                 }
                 ```
 

--- a/glym_spring/src/main/java/glym/glym_spring/global/config/SecurityConfig.java
+++ b/glym_spring/src/main/java/glym/glym_spring/global/config/SecurityConfig.java
@@ -99,16 +99,17 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOriginPatterns(List.of(
+        configuration.setAllowedOrigins(List.of(
                 "http://localhost:5173"
                 ,"http://localhost:3000",
                 "http://localhost:8080",
-                "http://ec2-15-164-102-179.ap-northeast-2.compute.amazonaws.com:8080")); // 허용할 오리진 TODO: CORS 경로 설정 "http://localhost:5173"
+                "http://ec2-15-164-102-179.ap-northeast-2.compute.amazonaws.com:8080"));
 
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")); // 허용할 HTTP 메서드
         configuration.setAllowCredentials(true); // 인증 정보 포함 여부
-        configuration.setAllowedHeaders(Collections.singletonList("*")); // 허용할 헤더
-        configuration.setExposedHeaders(Collections.singletonList("*"));
+        configuration.setAllowedHeaders(Collections.singletonList("*")); // 요청 받을 때 허용할 헤더
+        configuration.setExposedHeaders(List.of("Authorization", "refreshToken", "Authorization-refresh"));    //서버에서 보낼때!!!
+
         configuration.setMaxAge(3600L); // Preflight 캐싱 시간
 
         // 모든 경로에 대해 CORS 설정 적용

--- a/glym_spring/src/main/java/glym/glym_spring/global/filter/LoginFilter.java
+++ b/glym_spring/src/main/java/glym/glym_spring/global/filter/LoginFilter.java
@@ -17,6 +17,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -83,13 +84,24 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         response.addHeader("Authorization", "Bearer " + accessToken);
 
         // 쿠키에 refreshToken 추가
-        Cookie cookie = new Cookie("refreshToken", refreshToken);
+        /*Cookie cookie = new Cookie("refreshToken", refreshToken);
         cookie.setHttpOnly(true); // HttpOnly 설정
         //배포시 true 로 수정
         cookie.setSecure(false);
         cookie.setPath("/");
         cookie.setMaxAge((int) (jwtUtil.getRefreshExpirationTime() / 1000)); // 쿠키 maxAge는 초 단위 이므로, 밀리초를 1000으로 나눔
-        response.addCookie(cookie);
+        response.addCookie(cookie);*/
+
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(false) // 배포 환경에서는 true
+                .sameSite("None")
+                .path("/")
+                .maxAge(jwtUtil.getRefreshExpirationTime() / 1000)
+                .build();
+
+        response.setHeader("Set-Cookie", cookie.toString());
+
 
         // 로그인에 성공하면 유저 정보 반환
         response.setContentType("application/json");


### PR DESCRIPTION
🔧 작업 개요
HTTPS 인증서 적용 (Let's Encrypt, Certbot)

Nginx SSL 설정 및 80 → 443 리디렉션 추가

프론트엔드 BASE URL을 https://www.glymfont.store로 통일

API 엔드포인트 prefix를 /api/로 정리

SameSite, Secure, HttpOnly 쿠키 설정 적용

🧪 테스트 내용
로그인 후 accessToken 및 refreshToken 정상 발급 및 저장

인증/로그아웃 포함 모든 API 정상 작동

쿠키가 보안 정책에 따라 정상 설정되는지 확인

📌 기타
프론트와 백엔드 모두 같은 EC2 인스턴스에서 운영 중

www/비 www 도메인 모두 리디렉션 처리 완료